### PR TITLE
Display Salesforce integration on website

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -223,7 +223,7 @@
     "description": "Send events to a salesforce endpoint",
     "verified": true,
     "maintainer": "community",
-    "displayOnWebsiteLib": false,
+    "displayOnWebsiteLib": true,
     "type": "data_out",
     "imageLink": "https://raw.githubusercontent.com/Vinovest/posthog-salesforce/main/logo.png"
   },


### PR DESCRIPTION
- Changes `displayOnWebsiteLib` to `true` so the integration appears on the website