### PR TITLE
add array-splitter-plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -336,6 +336,15 @@
     "type": "data_in"
   },
   {
+    "name": "Array Splitter Plugin",
+    "url": "https://github.com/witty-works/posthog-array-splitter-plugin",
+    "description": "This PostHog plugin will create new events for any array elements at the specified location with the JSON of a specific event type.",
+    "verified": true,
+    "maintainer": "community",
+    "displayOnWebsiteLib": true,
+    "type": "data_in"
+  },
+  {
     "name": "Property Filter",
     "url": "https://github.com/witty-works/posthog-property-filter-plugin",
     "description": "This plugin will set all configured properties to null inside an ingested event.",


### PR DESCRIPTION
Right now PostHog cannot provide insights on array elements, this plugin make it possible by creating new events for each array element.