### PR TITLE
Add site apps to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -496,5 +496,32 @@
     "maintainer": "community",
     "displayOnWebsiteLib": true,
     "type": "ingestion_filtering"
+  },
+  {
+    "name": "Pineapple Mode",
+    "url": "https://github.com/PostHog/pineapple-mode-app",
+    "description": "Make any website better by adding falling pineapples or other types of rain.",
+    "verified": true,
+    "maintainer": "official",
+    "displayOnWebsiteLib": true,
+    "type": "site"
+  },
+  {
+    "name": "Notification Bar",
+    "url": "https://github.com/PostHog/notification-bar-app",
+    "description": "Show a notification bar on top of your site.",
+    "verified": true,
+    "maintainer": "official",
+    "displayOnWebsiteLib": true,
+    "type": "site"
+  },
+  {
+    "name": "Feedback Widget",
+    "url": "https://github.com/PostHog/feedback-app",
+    "description": "Collect feedback from your users with a small homepage widget.",
+    "verified": true,
+    "maintainer": "official",
+    "displayOnWebsiteLib": true,
+    "type": "site"
   }
 ]


### PR DESCRIPTION
- Add the three new site apps to plugins.json
- Add a new `"type": "site"` to separate these types of apps from others. I'm not sure how this 
- These apps work on cloud, but only on the *next* self-hosted instance. We might benefit from waiting to merge this before the next release.